### PR TITLE
Fixed pale hanging moss block loot_tables

### DIFF
--- a/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss.json
+++ b/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss.json
@@ -2,43 +2,42 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
+      "bonus_rolls": 0,
+      "conditions": [
+        {
+          "condition": "minecraft:any_of",
+          "terms": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "items": [
+                  "minecraft:shears"
+                ]
+              }
+            },
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "enchantments": [
+                  {
+                    "enchantment": "minecraft:silk_touch",
+                    "levels": {
+                      "min": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:any_of",
-              "terms": [
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "items": [
-                      "minecraft:shears"
-                    ]
-                  }
-                },
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ],
           "name": "palegardenbackport:pale_hanging_moss"
         }
       ],
-      "rolls": 1.0
+      "rolls": 1
     }
-  ],
-  "random_sequence": "palegardenbackport:blocks/pale_hanging_moss"
+  ]
 }

--- a/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss.json
+++ b/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss.json
@@ -2,7 +2,7 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0,
+      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:any_of",
@@ -37,7 +37,8 @@
           "name": "palegardenbackport:pale_hanging_moss"
         }
       ],
-      "rolls": 1
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "minecraft:blocks/pale_hanging_moss"
 }

--- a/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss_plant.json
+++ b/src/generated/resources/data/palegardenbackport/loot_tables/blocks/pale_hanging_moss_plant.json
@@ -2,43 +2,42 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
+      "bonus_rolls": 0,
+      "conditions": [
+        {
+          "condition": "minecraft:any_of",
+          "terms": [
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "items": [
+                  "minecraft:shears"
+                ]
+              }
+            },
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "enchantments": [
+                  {
+                    "enchantment": "minecraft:silk_touch",
+                    "levels": {
+                      "min": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "entries": [
         {
           "type": "minecraft:item",
-          "conditions": [
-            {
-              "condition": "minecraft:any_of",
-              "terms": [
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "items": [
-                      "minecraft:shears"
-                    ]
-                  }
-                },
-                {
-                  "condition": "minecraft:match_tool",
-                  "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ],
           "name": "palegardenbackport:pale_hanging_moss"
         }
       ],
-      "rolls": 1.0
+      "rolls": 1
     }
-  ],
-  "random_sequence": "palegardenbackport:blocks/pale_hanging_moss_plant"
+  ]
 }


### PR DESCRIPTION
Hanging moss blocks do not drop unless the player is using Shears that are enchanted with Silk Touch (not possible in Vanilla Survival). This change request fixes the block loot table, making them drop with Shears or any tools enchanted with Silk Touch (this is vanilla behavior).